### PR TITLE
delete second copy of githubv4

### DIFF
--- a/describe.go
+++ b/describe.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/cli/go-gh/v2/pkg/repository"
 	"github.com/gobwas/glob"
-	"github.com/shurcool/githubv4"
+	"github.com/shurcooL/githubv4"
 )
 
 var version = "unknown"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/alecthomas/kong v0.7.1
 	github.com/cli/go-gh/v2 v2.0.0
 	github.com/gobwas/glob v0.2.3
-	github.com/shurcool/githubv4 v0.0.0-20230424031643-6cea62ecd5a9
+	github.com/shurcooL/githubv4 v0.0.0-20230424031643-6cea62ecd5a9
 	github.com/stretchr/testify v1.8.1
 )
 
@@ -23,7 +23,6 @@ require (
 	github.com/muesli/termenv v0.12.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/shurcooL/githubv4 v0.0.0-20230424031643-6cea62ecd5a9 // indirect
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 // indirect
 	github.com/thlib/go-timezone-local v0.0.0-20210907160436-ef149e42d28e // indirect
 	golang.org/x/net v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,6 @@ github.com/shurcooL/githubv4 v0.0.0-20230424031643-6cea62ecd5a9 h1:nCBaIs5/R0HFP
 github.com/shurcooL/githubv4 v0.0.0-20230424031643-6cea62ecd5a9/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
 github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 h1:B1PEwpArrNp4dkQrfxh/abbBAOZBVp0ds+fBEOUOqOc=
 github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
-github.com/shurcool/githubv4 v0.0.0-20230424031643-6cea62ecd5a9 h1:CWlD9D4R1JSAGRGke/xwabcLvPSnOaf7mc27wpPZ1VU=
-github.com/shurcool/githubv4 v0.0.0-20230424031643-6cea62ecd5a9/go.mod h1:Rx+WSUainkHWg5qIfDBVuYoAU6fDL4/+A4/r1jryErg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=


### PR DESCRIPTION
There were two required modules providing the same package `githubv4`.
Delete second one whose module path doesn't match the [canonical one](https://github.com/shurcooL/githubv4/blob/095e54f8d08f48f2d886d983114bf5fec9c16ad3/go.mod#L1).